### PR TITLE
Expose interfaces for all api classes

### DIFF
--- a/DebridLinkFrNET/Apis/Account.cs
+++ b/DebridLinkFrNET/Apis/Account.cs
@@ -5,16 +5,8 @@ using System.Text;
 
 namespace DebridLinkFrNET.Apis
 {
-    public class AccountApi
+    public interface IAccountApi
     {
-        private readonly Store _store;
-        private readonly Requests _requests;
-        internal AccountApi(HttpClient httpClient, Store store)
-        {
-            _store = store;
-            _requests = new Requests(httpClient, store);
-        }
-
         /// <summary>
         ///     Get user infos
         /// </summary>
@@ -25,6 +17,20 @@ namespace DebridLinkFrNET.Apis
         /// <returns>
         ///     The informations about the connected user
         /// </returns>
+        Task<UserInfos> Infos(CancellationToken cancellationToken = default);
+    }
+
+    public class AccountApi : IAccountApi
+    {
+        private readonly Store _store;
+        private readonly Requests _requests;
+        internal AccountApi(HttpClient httpClient, Store store)
+        {
+            _store = store;
+            _requests = new Requests(httpClient, store);
+        }
+
+        /// <inheritdoc />
         public async Task<UserInfos> Infos(CancellationToken cancellationToken = default)
         {
             return await _requests.GetRequestAsync<UserInfos>("account/infos", true, null, cancellationToken);

--- a/DebridLinkFrNET/Apis/Downloader.cs
+++ b/DebridLinkFrNET/Apis/Downloader.cs
@@ -8,7 +8,44 @@ namespace DebridLinkFrNET.Apis
     /// <summary>
     /// Provides methods for interacting with the DebridLink.fr downloader API.
     /// </summary>
-    public class DownloaderApi
+    public interface IDownloaderApi
+    {
+        /// <summary>
+        /// Gets a list of hosted files from the downloader.
+        /// </summary>
+        /// <param name="page">The page number (starts at 0).</param>
+        /// <param name="perPage">Number of items per page (minimum: 20, maximum: 50).</param>
+        /// <param name="cancellationToken">Cancellation token for the operation.</param>
+        /// <returns>A list of hosted files.</returns>
+        Task<List<HostedFile>> ListAsync(int page = 0, int perPage = 50, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets a hosted file by its ID.
+        /// </summary>
+        /// <param name="idLink">The ID of the hosted file to retrieve.</param>
+        /// <param name="cancellationToken">Cancellation token for the operation.</param>
+        /// <returns>The hosted file with the specified ID, or null if not found.</returns>
+        Task<HostedFile> GetByIdAsync(string idLink, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Adds a hosted file to the downloader.
+        /// </summary>
+        /// <param name="url">The URL of the file to add.</param>
+        /// <param name="password">The optional password for the file.</param>
+        /// <param name="cancellationToken">Cancellation token for the operation.</param>
+        /// <returns>A list of hosted files, including the newly added file.</returns>
+        Task<List<HostedFile>> AddAsync(string url, string? password = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deletes one or more hosted files from the downloader.
+        /// </summary>
+        /// <param name="idLinks">The IDs of the hosted files to delete (comma-delimited or JSON).</param>
+        /// <param name="cancellationToken">Cancellation token for the operation.</param>
+        Task DeleteAsync(string idLinks, CancellationToken cancellationToken = default);
+    }
+
+   /// <inheritdoc />
+    public class DownloaderApi : IDownloaderApi
     {
         private readonly Store _store;
         private readonly Requests _requests;
@@ -19,13 +56,7 @@ namespace DebridLinkFrNET.Apis
             _requests = new Requests(httpClient, store);
         }
 
-        /// <summary>
-        /// Gets a list of hosted files from the downloader.
-        /// </summary>
-        /// <param name="page">The page number (starts at 0).</param>
-        /// <param name="perPage">Number of items per page (minimum: 20, maximum: 50).</param>
-        /// <param name="cancellationToken">Cancellation token for the operation.</param>
-        /// <returns>A list of hosted files.</returns>
+        /// <inheritdoc />
         public async Task<List<HostedFile>> ListAsync(int page = 0, int perPage = 50, CancellationToken cancellationToken = default)
         {
             var parameters = new Dictionary<string, string>
@@ -39,12 +70,7 @@ namespace DebridLinkFrNET.Apis
             return response ?? new List<HostedFile>();
         }
 
-        /// <summary>
-        /// Gets a hosted file by its ID.
-        /// </summary>
-        /// <param name="idLink">The ID of the hosted file to retrieve.</param>
-        /// <param name="cancellationToken">Cancellation token for the operation.</param>
-        /// <returns>The hosted file with the specified ID, or null if not found.</returns>
+        /// <inheritdoc />
         public async Task<HostedFile> GetByIdAsync(string idLink, CancellationToken cancellationToken = default)
         {
             List<HostedFile> response = new List<HostedFile>();
@@ -61,13 +87,7 @@ namespace DebridLinkFrNET.Apis
             return foundHostedFile;
         }
 
-        /// <summary>
-        /// Adds a hosted file to the downloader.
-        /// </summary>
-        /// <param name="url">The URL of the file to add.</param>
-        /// <param name="password">The optional password for the file.</param>
-        /// <param name="cancellationToken">Cancellation token for the operation.</param>
-        /// <returns>A list of hosted files, including the newly added file.</returns>
+        /// <inheritdoc />
         public async Task<List<HostedFile>> AddAsync(string url, string? password = null, CancellationToken cancellationToken = default)
         {
             var data = new[]
@@ -90,11 +110,7 @@ namespace DebridLinkFrNET.Apis
             return list;
         }
 
-        /// <summary>
-        /// Deletes one or more hosted files from the downloader.
-        /// </summary>
-        /// <param name="idLinks">The IDs of the hosted files to delete (comma-delimited or JSON).</param>
-        /// <param name="cancellationToken">Cancellation token for the operation.</param>
+        /// <inheritdoc />
         public async Task DeleteAsync(string idLinks, CancellationToken cancellationToken = default)
         {
             await _requests.DeleteRequestAsync<List<string>>($"downloader/{idLinks}/remove", true, null, cancellationToken);

--- a/DebridLinkFrNET/Apis/Seedbox.cs
+++ b/DebridLinkFrNET/Apis/Seedbox.cs
@@ -6,7 +6,63 @@ namespace DebridLinkFrNET.Apis
     /// <summary>
     /// Provides methods for interacting with the DebridLink.fr seedbox API.
     /// </summary>
-    public class SeedboxApi
+    public interface ISeedboxApi
+    {
+        /// <summary>
+        /// Retrieves a list of torrents from the seedbox.
+        /// </summary>
+        /// <param name="ids">Comma-delimited or JSON torrent IDs (maximum: 50).</param>
+        /// <param name="page">The page number (starts at 0).</param>
+        /// <param name="perPage">Number of items per page (minimum: 20, maximum: 50).</param>
+        /// <param name="cancellationToken">Cancellation token for the operation.</param>
+        /// <returns>A list of torrents from the seedbox.</returns>
+        Task<List<Torrent>> ListAsync(string? ids = null, int page = -1, int perPage = -1, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Adds a torrent to the seedbox by uploading a torrent file.
+        /// </summary>
+        /// <param name="file">The torrent file as a byte array.</param>
+        /// <param name="cancellationToken">Cancellation token for the operation.</param>
+        /// <returns>The added torrent.</returns>
+        Task<Torrent> AddTorrentByFileAsync(byte[] file, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Adds a torrent to the seedbox by URL.
+        /// </summary>
+        /// <param name="url">The URL of the torrent to add.</param>
+        /// <param name="wait">A value indicating whether to wait for the torrent to be ready for download.</param>
+        /// <param name="async">A value indicating whether to add the torrent asynchronously.</param>
+        /// <param name="cancellationToken">Cancellation token for the operation.</param>
+        /// <returns>The added torrent.</returns>
+        Task<Torrent> AddTorrentAsync(string url, bool wait = false, bool async = false, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Only return torrent(s) that are fully downloaded and ready.
+        /// </summary>
+        /// <param name="url">The Torrent URL (urlencoded), Magnet (urlencoded) or hash list (comma-delimited or json). (200 max.) for which to retrieve cached torrents.</param>
+        /// <param name="cancellationToken">Cancellation token for the operation.</param>
+        /// <returns>A dictionary of cached torrents keyed by the given identifier (Torrent URL (urlencoded), Magnet (urlencoded) or hash list (comma-delimited or json). (200 max.)).</returns>
+        Task<Dictionary<string, Torrent>> CachedAsync(string url, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Starts the configuration of a torrent on the seedbox.
+        /// </summary>
+        /// <param name="idTorrent">The ID of the torrent to configure.</param>
+        /// <param name="unwantedFileIds">An array of file IDs to mark as unwanted.</param>
+        /// <param name="cancellationToken">Cancellation token for the operation.</param>
+        /// <returns>A list of file IDs marked as unwanted.</returns>
+        Task<List<string>> StartAsync(string idTorrent, string[] unwantedFileIds, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deletes one or more hosted torrents from the seedbox.
+        /// </summary>
+        /// <param name="idTorrents">The IDs of the torrents to delete (comma-delimited or JSON).</param>
+        /// <param name="cancellationToken">Cancellation token for the operation.</param>
+        Task DeleteAsync(string idTorrents, CancellationToken cancellationToken = default);
+    }
+
+    /// <inheritdoc />
+    public class SeedboxApi : ISeedboxApi
     {
         private readonly Store _store;
         private readonly Requests _requests;
@@ -17,14 +73,7 @@ namespace DebridLinkFrNET.Apis
             _requests = new Requests(httpClient, store);
         }
 
-        /// <summary>
-        /// Retrieves a list of torrents from the seedbox.
-        /// </summary>
-        /// <param name="ids">Comma-delimited or JSON torrent IDs (maximum: 50).</param>
-        /// <param name="page">The page number (starts at 0).</param>
-        /// <param name="perPage">Number of items per page (minimum: 20, maximum: 50).</param>
-        /// <param name="cancellationToken">Cancellation token for the operation.</param>
-        /// <returns>A list of torrents from the seedbox.</returns>
+        /// <inheritdoc />
         public async Task<List<Torrent>> ListAsync(string? ids = null, int page = -1, int perPage = -1, CancellationToken cancellationToken = default)
         {
             var parameters = new Dictionary<string, string>
@@ -39,12 +88,7 @@ namespace DebridLinkFrNET.Apis
             return response ?? new List<Torrent>();
         }
 
-        /// <summary>
-        /// Adds a torrent to the seedbox by uploading a torrent file.
-        /// </summary>
-        /// <param name="file">The torrent file as a byte array.</param>
-        /// <param name="cancellationToken">Cancellation token for the operation.</param>
-        /// <returns>The added torrent.</returns>
+        /// <inheritdoc />
         public async Task<Torrent> AddTorrentByFileAsync(byte[] file, CancellationToken cancellationToken = default)
         {
             var result = await _requests.PostFileRequestAsync<Torrent>("seedbox/add", file, true, cancellationToken);
@@ -52,14 +96,7 @@ namespace DebridLinkFrNET.Apis
             return result;
         }
 
-        /// <summary>
-        /// Adds a torrent to the seedbox by URL.
-        /// </summary>
-        /// <param name="url">The URL of the torrent to add.</param>
-        /// <param name="wait">A value indicating whether to wait for the torrent to be ready for download.</param>
-        /// <param name="async">A value indicating whether to add the torrent asynchronously.</param>
-        /// <param name="cancellationToken">Cancellation token for the operation.</param>
-        /// <returns>The added torrent.</returns>
+        /// <inheritdoc />
         public async Task<Torrent> AddTorrentAsync(string url, bool wait = false, bool async = false, CancellationToken cancellationToken = default)
         {
             var data = new[]
@@ -74,12 +111,7 @@ namespace DebridLinkFrNET.Apis
             return result;
         }
 
-        /// <summary>
-        /// Only return torrent(s) that are fully downloaded and ready.
-        /// </summary>
-        /// <param name="url">The Torrent URL (urlencoded), Magnet (urlencoded) or hash list (comma-delimited or json). (200 max.) for which to retrieve cached torrents.</param>
-        /// <param name="cancellationToken">Cancellation token for the operation.</param>
-        /// <returns>A dictionary of cached torrents keyed by the given identifier (Torrent URL (urlencoded), Magnet (urlencoded) or hash list (comma-delimited or json). (200 max.)).</returns>
+        /// <inheritdoc />
         public async Task<Dictionary<string, Torrent>> CachedAsync(string url, CancellationToken cancellationToken = default)
         {
             var parameters = new Dictionary<string, string>();
@@ -90,13 +122,7 @@ namespace DebridLinkFrNET.Apis
             return response;
         }
 
-        /// <summary>
-        /// Starts the configuration of a torrent on the seedbox.
-        /// </summary>
-        /// <param name="idTorrent">The ID of the torrent to configure.</param>
-        /// <param name="unwantedFileIds">An array of file IDs to mark as unwanted.</param>
-        /// <param name="cancellationToken">Cancellation token for the operation.</param>
-        /// <returns>A list of file IDs marked as unwanted.</returns>
+        /// <inheritdoc />
         public async Task<List<string>> StartAsync(string idTorrent, string[] unwantedFileIds, CancellationToken cancellationToken = default)
         {
             var files = string.Join(",", unwantedFileIds);
@@ -111,11 +137,7 @@ namespace DebridLinkFrNET.Apis
             return response;
         }
 
-        /// <summary>
-        /// Deletes one or more hosted torrents from the seedbox.
-        /// </summary>
-        /// <param name="idTorrents">The IDs of the torrents to delete (comma-delimited or JSON).</param>
-        /// <param name="cancellationToken">Cancellation token for the operation.</param>
+        /// <inheritdoc />
         public async Task DeleteAsync(string idTorrents, CancellationToken cancellationToken = default)
         {
             await _requests.DeleteRequestAsync<List<string>>($"seedbox/{idTorrents}/remove", true, null, cancellationToken);

--- a/DebridLinkFrNET/DebridLinkFrNETClient.cs
+++ b/DebridLinkFrNET/DebridLinkFrNETClient.cs
@@ -2,17 +2,24 @@
 
 namespace DebridLinkFrNET;
 
+public interface IDebridLinkFrNETClient
+{
+    IAccountApi Account { get; }
+    ISeedboxApi Seedbox { get; }
+    IDownloaderApi Downloader { get; }
+}
+
 /// <summary>
 ///     The DebridLinkFrNET consumed the DebridLinkFr.com API.
 ///     Documentation about the API can be found here: https://docs.DebridLinkFr.com/
 /// </summary>
-public class DebridLinkFrNETClient
+public class DebridLinkFrNETClient : IDebridLinkFrNETClient
 {
     private readonly Store _store = new();
 
-    public AccountApi Account { get; }
-    public SeedboxApi Seedbox { get; }
-    public DownloaderApi Downloader { get; }
+    public IAccountApi Account { get; }
+    public ISeedboxApi Seedbox { get; }
+    public IDownloaderApi Downloader { get; }
 
     /// <summary>
     ///     Initialize the DebridLinkFrNET API.


### PR DESCRIPTION
By exposing these interfaces, consumers of the library can mock a `DebridLinkFrNETClient`

See also rogerfar/AllDebrid.NET#9, rogerfar/rdt-client#691.